### PR TITLE
Set SHELL in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ $(WIN64)-expat-configure     := --host=$(WIN64)
 $(WIN64)-libusb-configure    := --host=$(WIN64)
 $(WIN64)-libftdi-configure   := -DCMAKE_TOOLCHAIN_FILE="$(abspath $(SRC_LIBFTDI)/cmake/Toolchain-x86_64-w64-mingw32.cmake)" -DLIBUSB_LIBRARIES="$(abspath $(OBJ_WIN64)/install/riscv-openocd-$(ROCD_VERSION)-$(WIN64)/bin/libusb-1.0.dll)" -DLIBUSB_INCLUDE_DIR="$(abspath $(OBJ_WIN64)/install/riscv-openocd-$(ROCD_VERSION)-$(WIN64)/include/libusb-1.0)"
 $(UBUNTU32)-rgt-host         := --host=i686-linux-gnu
-$(UBUNTU32)-rgcc-configure   := --without-system-zlib
+$(UBUNTU32)-rgcc-configure   := --with-system-zlib
 $(UBUNTU32)-rocd-configure   := --host=i686-linux-gnu
 $(UBUNTU32)-expat-configure  := --host=i686-linux-gnu
 $(UBUNTU32)-libusb-configure := --host=i686-linux-gnu
 $(UBUNTU64)-rgt-host         := --host=x86_64-linux-gnu
-$(UBUNTU64)-rgcc-configure   := --without-system-zlib
+$(UBUNTU64)-rgcc-configure   := --with-system-zlib
 $(UBUNTU64)-rocd-configure   := --host=x86_64-linux-gnu
 $(UBUNTU64)-expat-configure  := --host=x86_64-linux-gnu
 $(UBUNTU64)-libusb-configure := --host=x86_64-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 .PHONY: all
 all:
 
+# Make uses /bin/sh by default, ignoring the user's value of SHELL.
+# Some systems now ship with /bin/sh pointing at dash, and this Makefile
+# requires bash
+SHELL = /bin/bash
+
 BINDIR := bin
 OBJDIR := obj
 SRCDIR := src

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Several standard packages are needed to build the tools on the different support
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install cmake autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf patchutils bc zlib1g-dev libexpat-dev libtool pkg-config mingw-w64
+    $ sudo apt-get install cmake autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf patchutils bc zlib1g-dev libexpat-dev libtool pkg-config mingw-w64 python texlive
 
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 


### PR DESCRIPTION
Some systems now ship with /bin/sh pointing at dash, and this Makefile requires
bash, so we set SHELL to make it work on any system.