### PR TITLE
Adding the examples folder to the output package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1135,6 +1135,7 @@ $(OBJDIR)/%/build/trace-decoder/trace-decoder/stamp: \
 	$(MAKE) -C $(dir $@) CROSSPREFIX=$($($@_TARGET)-tdc-cross) all &>$(dir $@)/make-build.log
 	cp $(dir $@)/Debug/dqr$($($@_TARGET)-tdc-binext) $(abspath $($@_INSTALL))
 	cp $(dir $@)/scripts/trace.tcl $(abspath $($@_INSTALL))
+	cp -R $(dir $@)/examples $(abspath $($@_INSTALL))
 	date > $@
 
 # Targets that don't build anything


### PR DESCRIPTION
Hey Carsten,

I added an examples directory to the trace decoder package that will hold various examples, including the itcprint.c source snippet to add printf style output to trace.  I updated the freedom-tools makefile to add the examples directory to the built package, but I have no way (right now) to test it.  Does this change look sane to you?  Can you run a quick build to see if it works.  The trace-decoder/example folder is committed to 'master'