### PR TITLE
Picolibc 1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1615,7 +1615,10 @@ $(OBJDIR)/%/build/riscv-gnu-toolchain/build-picolibc/stamp: \
 	mkdir -p $(dir $@)
 	meson $(dir $@) \
 	      $(SRC_PICOLIBC) \
-	      --prefix $(abspath $($@_INSTALL)) \
+	      -Dincludedir=picolibc/include \
+	      -Dlibdir=picolibc/lib \
+	      -Dsysroot-install=true \
+	      --prefix $(abspath $($@_INSTALL))/$(NEWLIB_TUPLE) \
 	      --cross-file $(SRC_PICOLIBC)/cross-riscv64-unknown-elf.txt
 	$(NINJA) -C $(dir $@) install >& $(dir $@)/make-install.log
 	date > $@


### PR DESCRIPTION
This updates picolibc to version 1.4 and makes it use the -Dsysroot-install=true option to use relative lib/include paths from gcc sysroot